### PR TITLE
refactor: simplified publications

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,10 +1,10 @@
 [package]
 name = "KADE_NETWORK"
-version = "1.0.0"
+version = "0.0.5"
 authors = []
 
 [addresses]
-kade="0x809001fa9030e21dbe72a45291ddf227610e9c228025c8d93670ddd894f4141d"
+kade="0xe519b74fd94be761a4879e5db5e6e1ea113697c69be5664eb053123a00a03334"
 [dev-addresses]
 
 [dependencies.AptosFramework]

--- a/sources/publications.move
+++ b/sources/publications.move
@@ -8,6 +8,7 @@ module kade::publications {
 
     use std::signer;
     use std::string;
+    use aptos_std::string_utils;
     use aptos_framework::account;
     use aptos_framework::event;
     use aptos_framework::timestamp;
@@ -19,27 +20,22 @@ module kade::publications {
     #[test_only]
     use kade::usernames;
 
-    const SEED: vector<u8> = b"kade::publicationsv1.0.3";
+    const SEED: vector<u8> = b"kade::publicationsv0.0.5";
 
     const EOperationNotPermitted: u64 = 101;
 
     struct State has key {
         publication_count: u64,
         reaction_count: u64,
-        comment_count: u64,
-        repost_count: u64,
-        quoute_count: u64,
         signer_capability:  account::SignerCapability,
         publication_create_events: event::EventHandle<PublicationCreate>,
+        publication_create_with_ref_events: event::EventHandle<PublicationCreateWithRef>,
         publication_remove_events: event::EventHandle<PublicationRemove>,
-        comment_create_events: event::EventHandle<CommentCreateEvent>,
-        comment_remove_events: event::EventHandle<CommentRemoveEvent>,
-        repost_create_events: event::EventHandle<RepostCreateEvent>,
-        repost_remove_events: event::EventHandle<RepostRemoveEvent>,
-        quote_create_events: event::EventHandle<QuoteCreateEvent>,
-        quote_remove_events: event::EventHandle<QuoteRemoveEvent>,
+        publication_remove_with_ref_events: event::EventHandle<PublicationRemoveWithRef>,
         reaction_create_events: event::EventHandle<ReactionCreateEvent>,
-        reaction_remove_events: event::EventHandle<ReactionRemoveEvent>
+        reaction_create_with_ref_events: event::EventHandle<ReactionCreateEventWithRef>,
+        reaction_remove_events: event::EventHandle<ReactionRemoveEvent>,
+        reaction_remove_with_ref_events: event::EventHandle<ReactionRemoveEventWithRef>,
     }
 
 
@@ -49,7 +45,22 @@ module kade::publications {
         payload: string::String,  // stringified json payload
         user_kid: u64,
         delegate: address,
-        timestamp: u64
+        timestamp: u64,
+        type: u64, // 1 for post, 2 for quotes , 3 for comments, 4 for reposts
+        reference_kid: u64, // should always reference a kid lower than the current kid
+        publication_ref: string::String
+    }
+
+    #[event]
+    struct PublicationCreateWithRef has store, drop { // This is only for interactions that have a reference to another publication
+        kid: u64,
+        payload: string::String,  // stringified json payload
+        user_kid: u64,
+        delegate: address,
+        timestamp: u64,
+        type: u64, // 1 for post, 2 for quotes , 3 for comments, 4 for reposts
+        publication_ref: string::String,
+        parent_ref: string::String // to make it easier for off chain clients to work with an offline first approach
     }
 
     #[event]
@@ -57,73 +68,36 @@ module kade::publications {
         kid: u64,
         user_kid: u64,
         delegate: address,
-        timestamp: u64,
+        timestamp: u64
     }
 
     #[event]
-    struct CommentCreateEvent has store, drop {
-        kid: u64,
-        reference_kid: u64,
+    struct PublicationRemoveWithRef has store, drop {
         user_kid: u64,
         delegate: address,
-        type: u64, // comment 1 for comment on publication, 2 for comment on quoute, 3 for comment on comment
         timestamp: u64,
-        content: string::String
+        ref: string::String
     }
 
-    #[event]
-    struct CommentRemoveEvent has store, drop {
-        kid: u64,
-        user_kid: u64,
-        delegate: address,
-        timestamp: u64,
-    }
-
-    #[event]
-    struct  RepostCreateEvent has store, drop {
-        kid: u64,
-        reference_kid: u64,
-        type: u64, // 1 for publication, 2 for quotes , 3 for comments
-        user_kid: u64,
-        delegate: address,
-        timestamp: u64,
-    }
-
-    #[event]
-    struct RepostRemoveEvent has store, drop {
-        kid: u64,
-        user_kid: u64,
-        delegate: address,
-        timestamp: u64,
-    }
-
-    #[event]
-    struct QuoteCreateEvent has store, drop {
-        kid: u64,
-        reference_kid: u64,
-        user_kid: u64,
-        delegate: address,
-        payload: string::String,
-        timestamp: u64,
-    }
-
-    #[event]
-    struct QuoteRemoveEvent has store, drop {
-        kid: u64,
-        user_kid: u64,
-        delegate: address,
-        timestamp: u64,
-    }
 
     #[event]
     struct ReactionCreateEvent has store, drop {
         kid: u64,
         reference_kid: u64,
-        type: u64,// 1 for publication, 2 for quotes , 3 for comments
         user_kid: u64,
         delegate: address,
         reaction: u64,
         timestamp: u64,
+    }
+
+    #[event]
+    struct ReactionCreateEventWithRef has store, drop {
+        kid: u64,
+        user_kid: u64,
+        delegate: address,
+        reaction: u64,
+        timestamp: u64,
+        publication_ref: string::String
     }
 
     #[event]
@@ -134,53 +108,83 @@ module kade::publications {
         timestamp: u64,
     }
 
+    #[event]
+    struct ReactionRemoveEventWithRef has store, drop {
+        user_kid: u64,
+        delegate: address,
+        timestamp: u64,
+        ref: string::String
+    }
+
 
     fun init_module(admin: &signer) {
         let (resource_signer, signer_capability ) = account::create_resource_account(admin, SEED);
 
         move_to(&resource_signer, State {
             signer_capability,
-            repost_count: 0,
-            reaction_count: 0,
-            comment_count: 0,
-            publication_count: 0,
-            quoute_count: 0,
-            comment_create_events: account::new_event_handle(&resource_signer),
-            comment_remove_events: account::new_event_handle(&resource_signer),
+            reaction_count: 100, // the first 100(0-99) kids are reserved for error codes
+            publication_count: 100, // the first 100(0-99) kids are reserved for error codes
             publication_create_events: account::new_event_handle(&resource_signer),
             publication_remove_events: account::new_event_handle(&resource_signer),
-            quote_create_events: account::new_event_handle(&resource_signer),
-            quote_remove_events: account::new_event_handle(&resource_signer),
+            publication_create_with_ref_events: account::new_event_handle(&resource_signer),
+            publication_remove_with_ref_events: account::new_event_handle(&resource_signer),
             reaction_create_events: account::new_event_handle(&resource_signer),
+            reaction_create_with_ref_events: account::new_event_handle(&resource_signer),
             reaction_remove_events: account::new_event_handle(&resource_signer),
-            repost_create_events: account::new_event_handle(&resource_signer),
-            repost_remove_events: account::new_event_handle(&resource_signer),
+            reaction_remove_with_ref_events: account::new_event_handle(&resource_signer),
         });
 
     }
 
 
-    public entry fun create_publication(delegate: &signer, payload: string::String) acquires  State {
+    public entry fun create_publication(delegate: &signer, type: u64, payload: string::String, reference_kid: u64, ref: string::String) acquires State {
+        let resource_address = account::create_resource_address(&@kade, SEED);
+        let delegate_address = signer::address_of(delegate);
+        let user_kid = accounts::get_delegate_owner(delegate);
+        let state = borrow_global_mut<State>(resource_address);
+        let kid = state.publication_count;
+        assert!(reference_kid < kid, 101);
+        state.publication_count = state.publication_count + 1;
+        let publication_ref = ref;
+        if(string::length(&ref) == 0){
+            publication_ref = string_utils::format1(&b"publication_kid_{}", kid);
+        };
+
+        event::emit_event(&mut state.publication_create_events, PublicationCreate {
+            delegate: delegate_address,
+            kid,
+            payload,
+            timestamp: timestamp::now_seconds(),
+            user_kid,
+            type,
+            reference_kid, // 0 means no reference
+            publication_ref
+        });
+    }
+
+    public entry fun create_publication_with_ref(delegate: &signer, type: u64, payload: string::String, ref: string::String, parent_ref: string::String) acquires State {
         let resource_address = account::create_resource_address(&@kade, SEED);
         let delegate_address = signer::address_of(delegate);
         let user_kid = accounts::get_delegate_owner(delegate);
         let state = borrow_global_mut<State>(resource_address);
         let kid = state.publication_count;
         state.publication_count = state.publication_count + 1;
+        assert!(string::length(&ref) > 0, 101);
+        let publication_ref = ref;
+        if(string::length(&ref) == 0){
+            publication_ref = string_utils::format1(&b"publication_kid_{}", kid);
+        };
 
-        event::emit_event(&mut state.publication_create_events, PublicationCreate {
+        event::emit_event(&mut state.publication_create_with_ref_events, PublicationCreateWithRef {
             delegate: delegate_address,
             kid,
-            timestamp: timestamp::now_seconds(),
             payload,
-            user_kid
+            timestamp: timestamp::now_seconds(),
+            user_kid,
+            type,
+            publication_ref,
+            parent_ref
         });
-    }
-
-    // DEFER GAS FEES
-    public entry fun gd_create_publication(admin: &signer, delegate: &signer, payload: string::String) acquires State {
-        assert!(signer::address_of(admin) == @kade, EOperationNotPermitted);
-        create_publication(delegate, payload);
     }
 
 
@@ -190,6 +194,7 @@ module kade::publications {
         let user_kid = accounts::get_delegate_owner(delegate);
         let resource_address = account::create_resource_address(&@kade, SEED);
         let state = borrow_global_mut<State>(resource_address);
+        assert!(kid < state.publication_count, 101);
 
         event::emit_event(&mut state.publication_remove_events, PublicationRemove {
             delegate: delegate_address,
@@ -199,126 +204,23 @@ module kade::publications {
         });
     }
 
-    public entry fun create_comment(delegate: &signer, reference_kid: u64, type: u64, content: string::String) acquires State {
-        let resource_address = account::create_resource_address(&@kade, SEED);
-        let delegate_address = signer::address_of(delegate);
-        let user_kid = accounts::get_delegate_owner(delegate);
-        let state = borrow_global_mut<State>(resource_address);
-        let kid = state.comment_count;
-        state.comment_count = state.comment_count + 1;
-
-        event::emit_event(&mut state.comment_create_events, CommentCreateEvent {
-            delegate: delegate_address,
-            kid,
-            reference_kid,
-            timestamp: timestamp::now_seconds(),
-            type,
-            user_kid,
-            content
-        });
-    }
-
-    // DEFER GAS FEES
-    public entry fun gd_create_comment(admin: &signer, delegate: &signer, reference_kid: u64, type: u64, content: string::String) acquires State {
-        assert!(signer::address_of(admin) == @kade, EOperationNotPermitted);
-        create_comment(delegate, reference_kid, type, content);
-    }
-
-    public entry fun remove_comment(delegate: &signer, kid: u64) acquires State {
+    public entry fun remove_publication_with_ref(delegate: &signer, ref: string::String) acquires State {
+        assert!(string::length(&ref) > 0, 101);
         let delegate_address = signer::address_of(delegate);
         let user_kid = accounts::get_delegate_owner(delegate);
         let resource_address = account::create_resource_address(&@kade, SEED);
-
         let state = borrow_global_mut<State>(resource_address);
 
-        event::emit_event(&mut state.comment_remove_events, CommentRemoveEvent {
+
+        event::emit_event(&mut state.publication_remove_with_ref_events, PublicationRemoveWithRef {
             delegate: delegate_address,
-            kid,
+            ref,
             timestamp: timestamp::now_seconds(),
             user_kid
         });
     }
 
-    public entry fun create_repost(delegate: &signer, reference_kid: u64, type: u64) acquires State {
-        let resource_address = account::create_resource_address(&@kade, SEED);
-        let delegate_address = signer::address_of(delegate);
-        let user_kid = accounts::get_delegate_owner(delegate);
-        let state = borrow_global_mut<State>(resource_address);
-        let kid = state.repost_count;
-        state.repost_count = state.repost_count + 1;
-
-
-        event::emit_event(&mut state.repost_create_events, RepostCreateEvent {
-            delegate: delegate_address,
-            kid,
-            reference_kid,
-            timestamp: timestamp::now_seconds(),
-            user_kid,
-            type
-        })
-    }
-
-    // DEFER GAS FEES
-    public entry fun gd_create_repost(admin: &signer, delegate: &signer, reference_kid: u64, type: u64) acquires State {
-        assert!(signer::address_of(admin) == @kade, EOperationNotPermitted);
-        create_repost(delegate, reference_kid, type);
-    }
-
-    public entry fun remove_repost(delegate: &signer, kid: u64) acquires State {
-        let delegate_address = signer::address_of(delegate);
-        let user_kid = accounts::get_delegate_owner(delegate);
-
-        let resource_address = account::create_resource_address(&@kade, SEED);
-
-        let state = borrow_global_mut<State>(resource_address);
-
-        event::emit_event(&mut state.repost_remove_events, RepostRemoveEvent {
-            delegate: delegate_address,
-            kid,
-            timestamp: timestamp::now_seconds(),
-            user_kid
-        });
-    }
-
-    public entry fun create_quote(delegate: &signer, reference_kid: u64, payload: string::String) acquires State {
-        let resource_address = account::create_resource_address(&@kade, SEED);
-        let delegate_address = signer::address_of(delegate);
-        let user_kid = accounts::get_delegate_owner(delegate);
-        let state = borrow_global_mut<State>(resource_address);
-        let kid = state.quoute_count;
-        state.quoute_count = state.quoute_count + 1;
-
-        event::emit_event(&mut state.quote_create_events, QuoteCreateEvent {
-            delegate: delegate_address,
-            kid,
-            reference_kid,
-            timestamp: timestamp::now_seconds(),
-            user_kid,
-            payload
-        });
-    }
-
-    // DEFER GAS FEES
-    public entry fun gd_create_quote(admin: &signer, delegate: &signer, reference_kid: u64, payload: string::String) acquires State {
-        assert!(signer::address_of(admin) == @kade, EOperationNotPermitted);
-        create_quote(delegate, reference_kid, payload);
-    }
-
-    public entry fun remove_quote(delegate: &signer, kid: u64) acquires State {
-        let delegate_address = signer::address_of(delegate);
-        let user_kid = accounts::get_delegate_owner(delegate);
-        let resource_address = account::create_resource_address(&@kade, SEED);
-        let state = borrow_global_mut<State>(resource_address);
-
-        event::emit_event(&mut state.quote_remove_events, QuoteRemoveEvent {
-            delegate: delegate_address,
-            kid,
-            timestamp: timestamp::now_seconds(),
-            user_kid
-        });
-    }
-
-    public entry fun create_reaction(delegate: &signer, reaction: u64, reference_kid: u64, type: u64) acquires State {
+    public entry fun create_reaction(delegate: &signer, reaction: u64, reference_kid: u64) acquires State {
         let resource_address = account::create_resource_address(&@kade, SEED);
         let delegate_address = signer::address_of(delegate);
         let user_kid = accounts::get_delegate_owner(delegate);
@@ -332,15 +234,27 @@ module kade::publications {
             reaction,
             timestamp: timestamp::now_seconds(),
             user_kid,
-            reference_kid,
-            type
+            reference_kid
         });
     }
 
-    // DEFER GAS FEES
-    public entry fun gd_create_reaction(admin: &signer, delegate: &signer, reaction: u64, reference_kid: u64, type: u64) acquires State {
-        assert!(signer::address_of(admin) == @kade, EOperationNotPermitted);
-        create_reaction(delegate, reaction, reference_kid, type);
+    public entry fun create_reaction_with_ref(delegate: &signer, reaction: u64, ref: string::String) acquires State {
+        assert!(string::length(&ref) > 0, 101);
+        let resource_address = account::create_resource_address(&@kade, SEED);
+        let delegate_address = signer::address_of(delegate);
+        let user_kid = accounts::get_delegate_owner(delegate);
+        let state = borrow_global_mut<State>(resource_address);
+        let kid = state.reaction_count;
+        state.reaction_count = state.reaction_count + 1;
+
+        event::emit_event(&mut state.reaction_create_with_ref_events, ReactionCreateEventWithRef {
+            delegate: delegate_address,
+            reaction,
+            timestamp: timestamp::now_seconds(),
+            user_kid,
+            publication_ref: ref,
+            kid
+        });
     }
 
     public entry fun remove_reaction(delegate: &signer, kid: u64) acquires State {
@@ -352,6 +266,21 @@ module kade::publications {
         event::emit_event(&mut state.reaction_remove_events, ReactionRemoveEvent {
             delegate: delegate_address,
             kid,
+            timestamp: timestamp::now_seconds(),
+            user_kid
+        });
+    }
+
+    public entry fun remove_reaction_with_ref(delegate: &signer, ref: string::String) acquires State {
+        assert!(string::length(&ref) > 0, 101);
+        let delegate_address = signer::address_of(delegate);
+        let user_kid = accounts::get_delegate_owner(delegate);
+        let resource_address = account::create_resource_address(&@kade, SEED);
+        let state = borrow_global_mut<State>(resource_address);
+
+        event::emit_event(&mut state.reaction_remove_with_ref_events, ReactionRemoveEventWithRef {
+            delegate: delegate_address,
+            ref,
             timestamp: timestamp::now_seconds(),
             user_kid
         });
@@ -374,11 +303,8 @@ module kade::publications {
 
         let state = borrow_global<State>(resource_address);
 
-        assert!(state.publication_count == 0,1);
-        assert!(state.reaction_count == 0,2);
-        assert!(state.comment_count == 0,3);
-        assert!(state.repost_count == 0,4);
-        assert!(state.quoute_count == 0,5);
+        assert!(state.publication_count == 100,1);
+        assert!(state.reaction_count == 100,2);
 
     }
 
@@ -402,16 +328,13 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.publication_count == 1,1);
-
-
-
+        assert!(state.publication_count == 101,1);
 
     }
 
@@ -436,13 +359,15 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
+
+        remove_publication(&delegate, 0);
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.publication_count == 1,1);
+        assert!(state.publication_count == 101,1);
 
     }
 
@@ -467,15 +392,14 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
-
-        create_comment(&delegate, 0, 1, string::utf8(b"COOL"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
+        create_publication(&delegate, 3, string::utf8(b"Hello World"), 100, string::utf8(b""));
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.comment_count == 1,1);
+        assert!(state.publication_count == 102,1);
 
     }
 
@@ -499,15 +423,17 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
 
-        create_comment(&delegate, 0, 1, string::utf8(b"COOL"));
+        create_publication(&delegate, 3, string::utf8(b"Hello World"), 100, string::utf8(b""));
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.comment_count == 1,1);
+        assert!(state.publication_count == 102,1);
+
+        remove_publication(&delegate, 101);
 
     }
 
@@ -531,114 +457,15 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
 
-        create_repost(&delegate, 0, 1);
-
-        let expected_resource_address = account::create_resource_address(&@kade, SEED);
-
-        let state = borrow_global<State>(expected_resource_address);
-
-        assert!(state.repost_count == 1,1);
-
-    }
-
-    #[test(admin = @kade)]
-    fun test_remove_repost(admin: &signer) acquires State {
-
-        let aptos_framework = account::create_account_for_test(@0x1);
-        let user = account::create_account_for_test(@0x2);
-        let delegate = account::create_account_for_test(@0x3);
-        account::create_account_for_test(@kade);
-
-        timestamp::set_time_has_started_for_testing(&aptos_framework);
-        let feature = features::get_module_event_feature();
-        features::change_feature_flags(&aptos_framework, vector[feature], vector[]);
-
-        accounts::invoke_init_module(admin);
-        usernames::invoke_init_module(admin);
-        init_module(admin);
-        usernames::claim_username(&user, string::utf8(b"kade"));
-        accounts::create_account(&user, string::utf8(b"kade"));
-
-        accounts::add_account_delegate(&user, &delegate);
-
-        create_publication(&delegate, string::utf8(b"Hello World"));
-
-        create_repost(&delegate, 0, 1);
+        create_publication(&delegate, 4, string::utf8(b"Hello World"), 100, string::utf8(b""));
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.repost_count == 1,1);
-
-
-        remove_repost(&delegate, 0);
-
-    }
-
-    #[test(admin = @kade)]
-    fun test_create_quote(admin: &signer) acquires State {
-
-        let aptos_framework = account::create_account_for_test(@0x1);
-        let user = account::create_account_for_test(@0x2);
-        let delegate = account::create_account_for_test(@0x3);
-        account::create_account_for_test(@kade);
-
-        timestamp::set_time_has_started_for_testing(&aptos_framework);
-        let feature = features::get_module_event_feature();
-        features::change_feature_flags(&aptos_framework, vector[feature], vector[]);
-
-        accounts::invoke_init_module(admin);
-        usernames::invoke_init_module(admin);
-        init_module(admin);
-        usernames::claim_username(&user, string::utf8(b"kade"));
-        accounts::create_account(&user, string::utf8(b"kade"));
-
-        accounts::add_account_delegate(&user, &delegate);
-
-        create_publication(&delegate, string::utf8(b"Hello World"));
-
-        create_quote(&delegate, 0, string::utf8(b"Hello World"));
-
-        let expected_resource_address = account::create_resource_address(&@kade, SEED);
-
-        let state = borrow_global<State>(expected_resource_address);
-
-        assert!(state.quoute_count == 1,1);
-
-    }
-
-    #[test(admin = @kade)]
-    fun test_remove_quote(admin: &signer) acquires State {
-
-        let aptos_framework = account::create_account_for_test(@0x1);
-        let user = account::create_account_for_test(@0x2);
-        let delegate = account::create_account_for_test(@0x3);
-        account::create_account_for_test(@kade);
-
-        timestamp::set_time_has_started_for_testing(&aptos_framework);
-        let feature = features::get_module_event_feature();
-        features::change_feature_flags(&aptos_framework, vector[feature], vector[]);
-
-        accounts::invoke_init_module(admin);
-        usernames::invoke_init_module(admin);
-        init_module(admin);
-        usernames::claim_username(&user, string::utf8(b"kade"));
-        accounts::create_account(&user, string::utf8(b"kade"));
-
-        accounts::add_account_delegate(&user, &delegate);
-
-        create_publication(&delegate, string::utf8(b"Hello World"));
-
-        create_quote(&delegate, 0, string::utf8(b"Hello World"));
-
-        let expected_resource_address = account::create_resource_address(&@kade, SEED);
-
-        let state = borrow_global<State>(expected_resource_address);
-
-        assert!(state.quoute_count == 1,1);
+        assert!(state.publication_count == 102,1);
 
     }
 
@@ -662,15 +489,15 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
 
-        create_reaction(&delegate, 1, 0, 0);
+        create_reaction(&delegate, 1, 100);
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.reaction_count == 1,1);
+        assert!(state.reaction_count == 101,1);
 
     }
 
@@ -694,15 +521,17 @@ module kade::publications {
 
         accounts::add_account_delegate(&user, &delegate);
 
-        create_publication(&delegate, string::utf8(b"Hello World"));
+        create_publication(&delegate, 1, string::utf8(b"Hello World"), 0, string::utf8(b""));
 
-        create_reaction(&delegate, 1, 0, 0);
+        create_reaction(&delegate, 1, 100);
+
+        remove_reaction(&delegate, 100);
 
         let expected_resource_address = account::create_resource_address(&@kade, SEED);
 
         let state = borrow_global<State>(expected_resource_address);
 
-        assert!(state.reaction_count == 1,1);
+        assert!(state.reaction_count == 101,1);
 
     }
 

--- a/sources/usernames.move
+++ b/sources/usernames.move
@@ -22,13 +22,13 @@ module kade::usernames {
     friend kade::accounts;
     friend kade::publications;
 
-    const SEED:vector<u8> = b"usernames";
+    const SEED:vector<u8> = b"kade::usernamesv0.0.5";
 
     const COLLECTION_NAME: vector<u8> = b"Kade Usernames Registry";
-    const COLLECTION_DESCRIPTION: vector<u8> = b"Collection of Kade's Registered Usernames";
+    const COLLECTION_DESCRIPTION: vector<u8> = b"Kade's Registered Usernames";
     const COLLECTION_URI: vector<u8> = b"https://kade.network"; // TODO: change to metadata url
 
-    const IDENTITY_IMAGE:vector<u8> = b"";
+    const IDENTITY_IMAGE:vector<u8> = b"https://orange-urban-sloth-806.mypinata.cloud/ipfs/QmP2uYhKYUHSB587AfQvLb7hdeN5vTpfp6MC81KL98mf5E";
 
 
     //  Errors
@@ -71,7 +71,7 @@ module kade::usernames {
         let registry = UsernameRegistry {
             signer_capability,
             registration_events: account::new_event_handle(&resource_account_signer),
-            registered_usernames: 0
+            registered_usernames: 100 // The first 100 ids are reserved for system error codes
         };
 
         move_to<UsernameRegistry>(&resource_account_signer, registry);
@@ -167,6 +167,14 @@ module kade::usernames {
         }
     }
 
+    #[view]
+    public fun get_username_token_address(username: string::String): address {
+        let resource_address = account::create_resource_address(&@kade, SEED);
+        let token_address = token::create_token_address(&resource_address, &string::utf8(COLLECTION_NAME), &username);
+
+        token_address
+    }
+
 
     // =====
     // TESTS
@@ -184,7 +192,7 @@ module kade::usernames {
 
         let registry = borrow_global<UsernameRegistry>(expected_resource_address);
 
-        assert!(registry.registered_usernames == 0, 1)
+        assert!(registry.registered_usernames == 100, 1)
 
     }
 
@@ -203,7 +211,7 @@ module kade::usernames {
 
         let registry = borrow_global<UsernameRegistry>(expected_resource_address);
 
-        assert!(registry.registered_usernames == 1, 1);
+        assert!(registry.registered_usernames == 101, 1);
 
         let count = event::counter(&registry.registration_events);
 
@@ -271,7 +279,7 @@ module kade::usernames {
 
         let registry = borrow_global<UsernameRegistry>(expected_resource_address);
 
-        assert!(registry.registered_usernames == 1, 1);
+        assert!(registry.registered_usernames == 101, 1);
 
         let count = event::counter(&registry.registration_events);
 


### PR DESCRIPTION
# Changes
- Simplified publications
- Added refs to make local first easier clientside 
- Left room for system error codes as part of the item ids
- updated tests